### PR TITLE
fix: v1.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Changed
 
 - Behaviors for `INotification` can now be used for post-handling processing as well (by placing logic AFTER the call to `next()`)
-- `IRequestHandler`'s `Handle` method now returns `Task` instead of `Task<Unit>` to be compatible with MediatR
+- `IRequestHandler's` `Handle` method now returns `Task` instead of `Task<Unit>` to be compatible with MediatR
 
 
 ## [1.1.0] - 2025-04-29

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,21 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [Unreleased]
+
+### Added
+
+- Guide for migrating from MediatR to FreeMediator
+
+
+## [1.1.1] - 2025-04-30
+
+### Changed
+
+- Behaviors for `INotification` can now be used for post-handling processing as well (by placing logic AFTER the call to `next()`)
+- `IRequestHandler`'s `Handle` method now returns `Task` instead of `Task<Unit>` to be compatible with MediatR
+
+
 ## [1.1.0] - 2025-04-29
 
 ### Added

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <!-- Directory.Build.props -->
 <Project>
     <PropertyGroup>
-        <Version>1.1.0</Version>
+        <Version>1.1.1</Version>
     </PropertyGroup>
 </Project>
 

--- a/src/FreeMediator/Handlers/IRequestHandler.cs
+++ b/src/FreeMediator/Handlers/IRequestHandler.cs
@@ -36,11 +36,10 @@ public interface IRequestHandler<in TRequest> : IBaseRequestHandler
 {
 	/// <summary>
 	///     Handler logic for the request. Any exceptions thrown will not be caught by the framework.
-	///     Must return <see cref="Unit" /> to represent the lack of return value.
 	///     <param name="request">Request being sent through the mediator</param>
 	///     <param name="cancellationToken">CancellationToken</param>
 	/// </summary>
-	Task<Unit> Handle(TRequest request, CancellationToken cancellationToken);
+	Task Handle(TRequest request, CancellationToken cancellationToken);
 }
 
 #endregion

--- a/src/FreeMediator/Services/Mediator.cs
+++ b/src/FreeMediator/Services/Mediator.cs
@@ -16,7 +16,7 @@ internal class Mediator : IMediator
 		var handlerType = typeof(IRequestHandler<,>).MakeGenericType(request.GetType(), typeof(TResponse));
 		var service = _serviceProvider.GetServices(handlerType).Cast<IBaseRequestHandler<TResponse>>().Single();
 
-		return await InvokePipelineAsync(request, t => service.Handle(request, t), cancellationToken);
+		return await InvokeRequestPipelineAsync(request, ct => service.Handle(request, ct), cancellationToken);
 	}
 
 	public async Task Send<TRequest>(TRequest request, CancellationToken cancellationToken)
@@ -28,11 +28,17 @@ internal class Mediator : IMediator
 
 		if (service is not null)
 		{
-			await InvokePipelineAsync(request, t => service.Handle(request, t), cancellationToken);
+			RequestHandlerDelegate<Unit> serviceHandler = async ct =>
+			{
+				await service.Handle(request, ct);
+				return Unit.Value;
+			};
+
+			await InvokeRequestPipelineAsync(request, serviceHandler, cancellationToken);
 		}
 		else // Maybe the user implemented the handler as IRequestHandler<TRequest, Unit>, let's check
 		{
-			await InvokePipelineAsync(request, t => _serviceProvider.GetRequiredService<IRequestHandler<TRequest, Unit>>().Handle(request, t), cancellationToken);
+			await InvokeRequestPipelineAsync(request, ct => _serviceProvider.GetRequiredService<IRequestHandler<TRequest, Unit>>().Handle(request, ct), cancellationToken);
 		}
 	}
 
@@ -44,29 +50,32 @@ internal class Mediator : IMediator
 
 		var services = _serviceProvider.GetServices<INotificationHandler<TNotification>>();
 
-		await InvokePipelineAsync(notification, cancellationToken);
-
-		List<Exception> exceptions = [];
-
-		foreach (var service in services)
+		NotificationHandlerDelegate serviceHandler = async ct =>
 		{
-			try
-			{
-				await service.Handle(notification, cancellationToken);
-			}
-			catch (Exception ex)
-			{
-				exceptions.Add(ex);
-			}
-		}
+			List<Exception> exceptions = [];
 
-		if (exceptions.Count > 0)
-		{
-			throw new AggregateException(exceptions);
-		}
+			foreach (var service in services)
+			{
+				try
+				{
+					await service.Handle(notification, ct);
+				}
+				catch (Exception ex)
+				{
+					exceptions.Add(ex);
+				}
+			}
+
+			if (exceptions.Count > 0)
+			{
+				throw new AggregateException(exceptions);
+			}
+		};
+
+		await InvokeNotificationPipelineAsync(notification, serviceHandler, cancellationToken);
 	}
 
-	private async Task<TResponse> InvokePipelineAsync<TResponse>(IBaseRequest request, RequestHandlerDelegate<TResponse> serviceHandler, CancellationToken cancellationToken)
+	private async Task<TResponse> InvokeRequestPipelineAsync<TResponse>(IBaseRequest request, RequestHandlerDelegate<TResponse> serviceHandler, CancellationToken cancellationToken)
 	{
 		var pipelineBehaviorType = typeof(IPipelineBehavior<,>).MakeGenericType(request.GetType(), typeof(TResponse));
 		var behaviors = _serviceProvider.GetServices(pipelineBehaviorType).Cast<IBaseRequestPipelineBehavior<TResponse>>();
@@ -78,16 +87,14 @@ internal class Mediator : IMediator
 		return await pipeline(cancellationToken);
 	}
 
-	private async Task InvokePipelineAsync(INotification notification, CancellationToken cancellationToken)
+	private async Task InvokeNotificationPipelineAsync(INotification notification, NotificationHandlerDelegate serviceHandler, CancellationToken cancellationToken)
 	{
 		var pipelineBehaviorType = typeof(IPipelineBehavior<>).MakeGenericType(notification.GetType());
 		var behaviors = _serviceProvider.GetServices(pipelineBehaviorType).Cast<IBaseNotificationPipelineBehavior>();
 
-		NotificationHandlerDelegate lastHandler = _ => Task.CompletedTask;
-
 		var pipeline = behaviors
 			.Reverse() // necessary to archive in-DI-order execution, due to the way they're piped together
-			.Aggregate(lastHandler, (next, pipeline) => t => pipeline.Handle(notification, next, t));
+			.Aggregate(serviceHandler, (next, pipeline) => t => pipeline.Handle(notification, next, t));
 
 		await pipeline(cancellationToken);
 	}

--- a/tests/FreeMediator.UnitTests/Configuration/MediatorConfigurationTests/RegisterServicesTests.cs
+++ b/tests/FreeMediator.UnitTests/Configuration/MediatorConfigurationTests/RegisterServicesTests.cs
@@ -153,7 +153,7 @@ file class FakeCommand : IRequest;
 
 file class FakeCommandHandler : IRequestHandler<FakeCommand>
 {
-	public Task<Unit> Handle(FakeCommand command, CancellationToken cancellationToken)
+	public Task Handle(FakeCommand command, CancellationToken cancellationToken)
 	{
 		throw new NotImplementedException();
 	}
@@ -161,7 +161,7 @@ file class FakeCommandHandler : IRequestHandler<FakeCommand>
 
 file class FakeCommandHandler2 : IRequestHandler<FakeCommand>
 {
-	public Task<Unit> Handle(FakeCommand request, CancellationToken cancellationToken)
+	public Task Handle(FakeCommand request, CancellationToken cancellationToken)
 	{
 		throw new NotImplementedException();
 	}
@@ -207,7 +207,7 @@ file class InvalidGenericNotificationHandler<TNotification, T> : INotificationHa
 file class InvalidSingleArgumentGenericRequestHandler<TRequest> : IRequestHandler<TRequest>
 	where TRequest : IRequest
 {
-	public Task<Unit> Handle(TRequest request, CancellationToken cancellationToken)
+	public Task Handle(TRequest request, CancellationToken cancellationToken)
 	{
 		throw new NotImplementedException();
 	}

--- a/tests/FreeMediator.UnitTests/Services/SenderTests.cs
+++ b/tests/FreeMediator.UnitTests/Services/SenderTests.cs
@@ -143,10 +143,10 @@ file class CommandHandler : IRequestHandler<CommandRequest>
 {
 	public static List<string> HandledMessages { get; } = [];
 
-	public Task<Unit> Handle(CommandRequest request, CancellationToken cancellationToken)
+	public Task Handle(CommandRequest request, CancellationToken cancellationToken)
 	{
 		HandledMessages.Add(request.Message);
-		return Unit.Task;
+		return Task.CompletedTask;
 	}
 }
 
@@ -158,16 +158,16 @@ file class MultiCommandHandler : IRequestHandler<FirstMultiCommand>, IRequestHan
 {
 	public static List<string> HandledMessages { get; } = [];
 
-	public Task<Unit> Handle(FirstMultiCommand command, CancellationToken cancellationToken)
+	public Task Handle(FirstMultiCommand command, CancellationToken cancellationToken)
 	{
 		HandledMessages.Add(command.Message);
-		return Unit.Task;
+		return Task.CompletedTask;
 	}
 
-	public Task<Unit> Handle(SecondMultiCommand command, CancellationToken cancellationToken)
+	public Task Handle(SecondMultiCommand command, CancellationToken cancellationToken)
 	{
 		HandledMessages.Add(command.Message);
-		return Unit.Task;
+		return Task.CompletedTask;
 	}
 }
 
@@ -196,10 +196,10 @@ file class MixedRequestHandler : IRequestHandler<MixedCommand>, IRequestHandler<
 {
 	public static List<string> HandledMessages { get; } = [];
 
-	public Task<Unit> Handle(MixedCommand request, CancellationToken cancellationToken)
+	public Task Handle(MixedCommand request, CancellationToken cancellationToken)
 	{
 		HandledMessages.Add(request.Message);
-		return Unit.Task;
+		return Task.CompletedTask;
 	}
 
 	public Task<string> Handle(MixedRequest request, CancellationToken cancellationToken)


### PR DESCRIPTION
- Behaviors for `INotification` can now be used for post-handling processing as well (by placing logic AFTER the call to `next()`)
- `IRequestHandler's` `Handle` method now returns `Task` instead of `Task<Unit>` to be compatible with MediatR